### PR TITLE
update github action deploy token keyname

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -59,8 +59,8 @@ jobs:
     - name: Build and publish
       if: steps.check-branch.outputs.match == 'true'
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/examples/auto-reply-bot.py
+++ b/examples/auto-reply-bot.py
@@ -1,0 +1,30 @@
+"""daily plugin bot examples"""
+import asyncio
+from datetime import datetime
+from typing import List
+
+from wechaty import Wechaty  # type: ignore
+from wechaty_puppet import RoomQueryFilter  # type: ignore
+
+from wechaty_plugin_contrib import (
+    AutoReplyRule,
+    AutoReplyPlugin,
+    AutoReplyOptions
+)
+
+
+def get_rules() -> List[AutoReplyRule]:
+    return [
+        AutoReplyRule(keyword='ding', reply_content='dong'),
+        AutoReplyRule(keyword='wechaty', reply_content='hello-wechaty')
+    ]
+
+
+async def run():
+    """async run method"""
+
+    plugin = AutoReplyPlugin(AutoReplyOptions(rules=get_rules()))
+    bot = Wechaty().use(plugin)
+    await bot.start()
+
+asyncio.run(run())

--- a/examples/auto-reply-bot.py
+++ b/examples/auto-reply-bot.py
@@ -1,10 +1,8 @@
 """daily plugin bot examples"""
 import asyncio
-from datetime import datetime
 from typing import List
 
 from wechaty import Wechaty  # type: ignore
-from wechaty_puppet import RoomQueryFilter  # type: ignore
 
 from wechaty_plugin_contrib import (
     AutoReplyRule,
@@ -14,6 +12,7 @@ from wechaty_plugin_contrib import (
 
 
 def get_rules() -> List[AutoReplyRule]:
+    """get the default auto-reply configuration"""
     return [
         AutoReplyRule(keyword='ding', reply_content='dong'),
         AutoReplyRule(keyword='wechaty', reply_content='hello-wechaty')


### PR DESCRIPTION
When github action deploy the pypi package, it should keep the name same as account:

```shell
TWINE_USERNAME: __token__
TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
```